### PR TITLE
Add task 12

### DIFF
--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -62,44 +62,60 @@ describe("GET /api", () => {
 })
 
 
-
-// GET /api/articles/:article_id
+// GET /api/articles/:article_id (comment_count)
 describe("GET /api/articles/:article_id", () => {
+
+  test("Status 200: responds with an individual object which contains the articles properties", () => {
+    return request(app)
+      .get("/api/articles/9")
+      .expect(200)
+      .then(({ body }) => {
+          expect(body.article).toMatchObject({
+            title: "They're not exactly dogs, are they?",
+            topic: "mitch",
+            author: "butter_bridge",
+            body: "Well? Think about it.",
+            created_at: "2020-06-06T09:10:00.000Z",
+            article_img_url:
+              "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+          })
+      })
+  })
     
-  test("Status 200: responds with an individual object", () => {
-      return request(app)
-        .get("/api/articles/2")
-        .expect(200)
-        .then(({ body }) => {
-            expect(body.article).toMatchObject({
-              author: "icellusedkars",
-              title: "Sony Vaio; or, The Laptop",
-              article_id: 2,
-              body: "Call me Mitchell. Some years ago—never mind how long precisely—having little or no money in my purse, and nothing particular to interest me on shore, I thought I would buy a laptop about a little and see the codey part of the world. It is a way I have of driving off the spleen and regulating the circulation. Whenever I find myself growing grim about the mouth; whenever it is a damp, drizzly November in my soul; whenever I find myself involuntarily pausing before coffin warehouses, and bringing up the rear of every funeral I meet; and especially whenever my hypos get such an upper hand of me, that it requires a strong moral principle to prevent me from deliberately stepping into the street, and methodically knocking people’s hats off—then, I account it high time to get to coding as soon as I can. This is my substitute for pistol and ball. With a philosophical flourish Cato throws himself upon his sword; I quietly take to the laptop. There is nothing surprising in this. If they but knew it, almost all men in their degree, some time or other, cherish very nearly the same feelings towards the the Vaio with me.",
-              topic: "mitch",
-              created_at: "2020-10-16T05:03:00.000Z",
-              votes: 0,
-              article_img_url: "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
-            })
-        })
+  test("Status 200: responds with an individual object which contains comment_count added to the articles properties", () => {
+    return request(app)
+      .get("/api/articles/9?comment_count=9")
+      .expect(200)
+      .then(({ body }) => {
+          expect(body.article).toMatchObject({
+            title: "They're not exactly dogs, are they?",
+            topic: "mitch",
+            author: "butter_bridge",
+            body: "Well? Think about it.",
+            created_at: "2020-06-06T09:10:00.000Z",
+            article_img_url:
+              "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+              comment_count: 2
+          })
+      })
   })
 
-  test("Status 400: responds with an error message when article_id is an invalid type", () => {
+  test("Status 400: responds with an appropriate error message when article_id is an invalid type", () => {
     return request(app)
-        .get("/api/articles/notAnID")
-            .expect(400)
-            .then(({ body }) => {
-              expect(body.msg).toBe("Bad Request")
-            })
+      .get("/api/articles/notAnID")
+      .expect(400)
+      .then(({ body }) => {
+          expect(body.msg).toBe("Bad Request")
+      })
   })
 
-  test("Status 404: responds with an error message when article_id is valid but doesn't exist", () => {
+  test("Status 404: responds with an appropriate error message when article_id is valid but doesn't exist", () => {
     return request(app)
-        .get("/api/articles/1000")
-            .expect(404)
-            .then(({ body }) => {
-              expect(body.msg).toBe("Article Not Found")
-            })
+      .get("/api/articles/1000")
+      .expect(404)
+      .then(({ body }) => {
+          expect(body.msg).toBe("Article Not Found")
+      })
   })
 
 })
@@ -305,8 +321,7 @@ describe("PATCH /api/articles/:article_id", () => {
                   votes: 104,
                   article_img_url:
                     "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
-                })
-    
+                })   
   })
 
 })

--- a/app.js
+++ b/app.js
@@ -21,8 +21,6 @@ app.delete("/api/comments/:comment_id", deleteComment)
 
 app.get("/api/users", getUsers)
 
-
-
 app.all("*", (req, res) => {
     res.status(404).send({ msg: "Route Not Found" })
 })

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -19,8 +19,9 @@ exports.getEndpoints = (req, res) => {
 }
 
 exports.getArticleById = (req, res, next) => {
-    const article_id = req.params.article_id 
-    return selectArticleById(article_id)
+    const articleId = req.params.article_id 
+    const commentCount = req.query.comment_count 
+    return selectArticleById(articleId, commentCount)
       .then((article) => {
         res.status(200).send({ article })
       })

--- a/endpoints.json
+++ b/endpoints.json
@@ -28,7 +28,7 @@
   },
   "GET /api/articles/:article_id": {
     "description": "serves an object of one article",
-    "queries": [],
+    "queries": ["comment_count"],
     "exampleResponse": {
       "author": "icellusedkars",
       "title": "Sony Vaio; or, The Laptop",
@@ -37,7 +37,8 @@
       "topic": "mitch",
       "created_at": "2020-10-16T05:03:00.000Z",
       "votes": 0,
-      "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+      "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+      "comment_count": 0
     }
   },
   "GET /api/articles/:article_id/comments": {

--- a/models/models.js
+++ b/models/models.js
@@ -8,14 +8,28 @@ exports.selectTopics = () => {
        })
 }
 
-exports.selectArticleById = (article_id) => {
-   return db.query(`SELECT * FROM articles WHERE article_id = $1;`, [article_id])
-      .then((result) => {
-         if (result.rows.length === 0) {
-            return Promise.reject({ status: 404, msg: "Article Not Found" })    
-         }
-         return result.rows[0]
-      })
+exports.selectArticleById = (articleId, commentCount) => {
+   if (!commentCount) {
+      return db.query(`SELECT * FROM articles WHERE article_id = $1;`, [articleId])
+         .then((result) => {
+            if (result.rows.length === 0) {
+               return Promise.reject({ status: 404, msg: "Article Not Found" })    
+            }
+            return result.rows[0]
+         })
+   }
+
+   else {
+      return db.query(`SELECT articles.*, CAST(COUNT(comments.comment_id) AS INTEGER) AS comment_count 
+      FROM articles
+      LEFT JOIN comments
+      ON articles.article_id = comments.article_id
+      WHERE articles.article_id = $1
+      GROUP BY articles.article_id;`, [articleId])
+         .then((result) => {
+           return result.rows[0]
+         })
+   }
 }
 
 exports.selectArticles = (topic) => {


### PR DESCRIPTION
GET /api/articles/:article_id (comment_count):  
An article response object should also now include:
comment_count, which is the total count of all the comments with this article_id

update endpoints.json